### PR TITLE
🏫 Add collections to action and remove --key from submit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,14 @@ on:
         description: The site or venue that this project is being submitted to
         required: true
         type: string
+      collection:
+        description: The venue's collection that this project is being submitted to
+        type: string
       kind:
-        description: The kind of the submission
+        description: |
+          The kind of the submission
+
+          Available kinds are dependent on the venue and collection
         required: true
         type: string
       id-pattern-regex:
@@ -135,6 +141,7 @@ jobs:
         with:
           id: ${{ matrix.id }}
           venue: ${{ inputs.venue }}
+          collection: ${{ inputs.collection }}
           kind: ${{ inputs.kind }}
           working-directory: ${{ matrix.working-directory }}
           draft: ${{ matrix.draft }}

--- a/submit/action.yml
+++ b/submit/action.yml
@@ -6,7 +6,10 @@ branding:
   color: blue
 inputs:
   id:
-    description: The ID of the submission, used to maintain the submission history as well as store the logs on github
+    description: |
+      The ID of the submission, used to store the logs on github
+
+      This should match the submission id in the myst.yml project config
     required: true
   working-directory:
     description: Install typst for PDF rendering
@@ -14,6 +17,8 @@ inputs:
   venue:
     description: The site or venue that this project is being submitted to
     required: true
+  collection:
+    description: The venue's collection that this project is being submitted to
   kind:
     description: The kind of the submission
     required: true
@@ -28,10 +33,12 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.draft }}" = "true" ]; then
-          curvenote submit ${{ inputs.venue }} --kind "${{ inputs.kind }}" --draft -y
-        else
-          curvenote submit ${{ inputs.venue }} --kind "${{ inputs.kind }}" --key ${{ inputs.id }} -y
+          DRAFT="--draft"
         fi
+        if [ "${{ inputs.collection }}" ]
+          COLLECTION="--collection ${{ inputs.collection }}"
+        fi
+        curvenote submit ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION $DRAFT -y
     - name: Upload Curvenote Logs
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Action has new input `collection` which is used to select a venue collection. It is optional, for venues with only one collection. However, if a venue has multiple collections, it must be specified or the action will fail (maybe hang, waiting for input...? We should maybe update the CLI to error on `-y` in this case).

This also removes the `--key` argument to `curvenote submit` - that argument is no longer valid, key is always pulled from `myst.yml`