### PR TITLE
🔀 Update concurrency group to use head

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,7 +137,7 @@ jobs:
     needs: strategy
     runs-on: ubuntu-latest
     concurrency:
-      group: preview-${{ github.repository }}-${{ github.ref }}
+      group: preview-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}
       cancel-in-progress: true
     if: ${{ needs.strategy.outputs.preview == 'true'}}
     strategy:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@curvenote/actions",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@curvenote/actions",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "workspaces": [
         "strategy",
         "submit-summary"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@curvenote/actions",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "workspaces": [
     "strategy",
     "submit-summary"


### PR DESCRIPTION
Another attempt to address #17 - we need to use the `head` repo/branch on the concurrency group.