### PR TITLE
💨 Updates for single-article repo

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
           fetch-depth: 1
       - name: Get changed files
         id: changed-files
@@ -120,7 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
           fetch-depth: 1
       - uses: curvenote/actions/setup@main
       - uses: curvenote/actions/submit@main
@@ -142,7 +142,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
           fetch-depth: 1
       - uses: curvenote/actions/setup@main
         with:

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -62,6 +62,15 @@ on:
       ref:
         description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
         type: string
+      comment:
+        description: |
+          By default, the draft workflow will create a summary comment on the PR / commit. If the action file
+          does not grant sufficient permissions for this, the action will fail.
+
+          Setting `comment: false` stops the workflow from attempting to comment, allowing the action to pass
+          without write permissions.
+        default: true
+        type: boolean
     secrets:
       GITHUB:
         description: GitHub API token (usually `env.GITHUB_TOKEN`)
@@ -159,6 +168,7 @@ jobs:
         id: summary
         with:
           matrix: '${{ needs.strategy.outputs.matrix }}'
-      - uses: curvenote/actions/upsert-comment@main
+      - if: ${{ inputs.comment }}
+        uses: curvenote/actions/upsert-comment@main
         with:
           comment: '${{ steps.summary.outputs.comment }}'

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -51,6 +51,14 @@ on:
         required: false
         default: 'false'
         type: string
+      label:
+        description: |
+          A pull request label that indicates the preview should be run.
+          Multiple labels can be added with comma-separated values.
+
+          If no label is supplied, the preview will run on all PRs.
+        required: false
+        type: string
       ref:
         description: |
           The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow,
@@ -98,7 +106,7 @@ jobs:
           path: ${{ inputs.path }}
           enforce-single-folder: ${{ inputs.enforce-single-folder }}
           id-pattern-regex: ${{ inputs.id-pattern-regex }}
-          preview-label: true
+          preview-label: ${{ inputs.label || true }}
   submit-draft:
     needs: strategy
     runs-on: ubuntu-latest

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -169,6 +169,5 @@ jobs:
         with:
           matrix: '${{ needs.strategy.outputs.matrix }}'
       - uses: curvenote/actions/upsert-comment@main
-        if: ${{ github.event.pull_request.number }}
         with:
           comment: '${{ steps.summary.outputs.comment }}'

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -78,9 +78,6 @@ on:
       CURVENOTE:
         description: Curvenote API token (usually `secrets.CURVENOTE_TOKEN`)
         required: true
-permissions:
-  contents: read
-  pull-requests: write
 jobs:
   strategy:
     runs-on: ubuntu-latest
@@ -150,7 +147,8 @@ jobs:
           typst: false
           images: false
       # Note, the collection shouldn't be necessary:
-      - run: |
+      - name: Run curvenote check
+        run: |
           if [ -n "${{ inputs.collection }}" ]; then
             COLLECTION="--collection ${{ inputs.collection }}"
           fi

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -109,7 +109,7 @@ jobs:
     needs: strategy
     runs-on: ubuntu-latest
     concurrency:
-      group: submit-draft-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}
+      group: submit-draft-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}-${{ matrix.working-directory }}
       cancel-in-progress: true
     if: ${{ needs.strategy.outputs.preview == 'true'}}
     strategy:

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -159,7 +159,6 @@ jobs:
         env:
           CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
   summary:
-    if: github.event_name == 'pull_request'
     needs:
       - strategy
       - submit-draft
@@ -172,5 +171,6 @@ jobs:
         with:
           matrix: '${{ needs.strategy.outputs.matrix }}'
       - uses: curvenote/actions/upsert-comment@main
+        if: ${{ github.event.pull_request.number }}
         with:
           comment: '${{ steps.summary.outputs.comment }}'

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,0 +1,175 @@
+name: draft
+on:
+  workflow_call:
+    inputs:
+      venue:
+        description: The site or venue that this project is being submitted to
+        required: true
+        type: string
+      collection:
+        description: The venue's collection that this collection is being submitted to
+        type: string
+      kind:
+        description: |
+          The kind of the submission
+
+          Available kinds are dependent on the venue and collection
+        required: true
+        type: string
+      id-pattern-regex:
+        description: |
+          A regular expression that all IDs must follow, by default this matches a UUID.
+
+          This can be used to enforce that all project IDs follow a specific pattern, such as,
+          the conference name + year.
+
+          The ID must also satisfy alphanumeric characters, dashes, and underscores.
+        type: string
+        default: '^([a-zA-Z0-9-]{36})$'
+      monorepo:
+        description: |
+          Indicate that this repository contains multiple projects that should be published.
+
+          For example, if you have multiple articles, or tutorials that should be previewed
+          and submitted when there are changes in the repository.
+        required: false
+        default: false
+        type: boolean
+      path:
+        description: |
+          The root directory path(s) where the Curvenote CLI will be invoked.
+          If `multiple` paths are being used, separate the `path` string with ','.
+          The paths can also be glob-like patterns (but only one `*`), for example:
+
+          ```yaml
+          path: my/project
+          path: my/paper, my/poster
+          path: papers/*, posters/*
+          ```
+
+          The default path is the root of the repository.
+        required: false
+        default: '.'
+        type: string
+      enforce-single-folder:
+        description: |
+          When true, an error will be raised if a pull-request is touching multiple
+          different folders. This can either be `true` or a label string.
+          Multiple labels can be added with comma-separated values.
+
+          If labels are used to control this property, the pull request will only fail in
+          PRs with these labels.
+
+          This can be used in conjunction with the `preview-label`, for example, if they
+          are both `paper` then the PRs with those labels will be required to only make changes
+          in a single folder and will not be previewed if that condition fails.
+          However, you can add additional preview labels, e.g. `all-papers`, which will build
+          previews for all papers, as the single folder condition is not enforced for that label.
+        required: false
+        default: 'false'
+        type: string
+      ref:
+        description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
+        type: string
+    secrets:
+      GITHUB:
+        description: GitHub API token (usually `env.GITHUB_TOKEN`)
+        required: true
+      CURVENOTE:
+        description: Curvenote API token (usually `secrets.CURVENOTE_TOKEN`)
+        required: true
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  strategy:
+    runs-on: ubuntu-latest
+    outputs:
+      check: ${{ steps.build-strategy.outputs.check }}
+      preview: ${{ steps.build-strategy.outputs.preview }}
+      matrix: ${{ steps.build-strategy.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          separator: ','
+      - id: build-strategy
+        uses: curvenote/actions/strategy@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB }}
+        with:
+          changed-files: ${{ steps.changed-files.outputs.all_changed_files }}
+          monorepo: ${{ inputs.monorepo }}
+          path: ${{ inputs.path }}
+          enforce-single-folder: ${{ inputs.enforce-single-folder }}
+          id-pattern-regex: ${{ inputs.id-pattern-regex }}
+  submit-draft:
+    needs: strategy
+    runs-on: ubuntu-latest
+    concurrency:
+      group: preview-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}
+      cancel-in-progress: true
+    if: ${{ needs.strategy.outputs.preview == 'true'}}
+    strategy:
+      matrix: ${{fromJson(needs.strategy.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+      - uses: curvenote/actions/setup@main
+      - uses: curvenote/actions/submit@main
+        env:
+          CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
+        with:
+          id: ${{ matrix.id }}
+          venue: ${{ inputs.venue }}
+          collection: ${{ inputs.collection }}
+          kind: ${{ inputs.kind }}
+          working-directory: ${{ matrix.working-directory }}
+          draft: true
+  check:
+    needs: strategy
+    runs-on: ubuntu-latest
+    if: ${{ needs.strategy.outputs.check == 'true'}}
+    strategy:
+      matrix: ${{fromJson(needs.strategy.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+      - uses: curvenote/actions/setup@main
+        with:
+          typst: false
+          images: false
+      # Note, the collection shouldn't be necessary:
+      - run: |
+          if [ -n "${{ inputs.collection }}" ]; then
+            COLLECTION="--collection ${{ inputs.collection }}"
+          fi
+          curvenote check ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION
+        working-directory: ${{ matrix.working-directory }}
+        env:
+          CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
+  summary:
+    if: github.event_name == 'pull_request'
+    needs:
+      - strategy
+      - preview
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB }}
+    steps:
+      - uses: curvenote/actions/submit-summary@main
+        id: summary
+        with:
+          matrix: '${{ needs.strategy.outputs.matrix }}'
+      - uses: curvenote/actions/upsert-comment@main
+        with:
+          comment: '${{ steps.summary.outputs.comment }}'

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -108,6 +108,7 @@ jobs:
           path: ${{ inputs.path }}
           enforce-single-folder: ${{ inputs.enforce-single-folder }}
           id-pattern-regex: ${{ inputs.id-pattern-regex }}
+          preview-label: true
   submit-draft:
     needs: strategy
     runs-on: ubuntu-latest

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -101,7 +101,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB }}
         with:
           changed-files: ${{ steps.changed-files.outputs.all_changed_files }}
-          monorepo: ${{ inputs.monorepo }}
           path: ${{ inputs.path }}
           enforce-single-folder: ${{ inputs.enforce-single-folder }}
           id-pattern-regex: ${{ inputs.id-pattern-regex }}

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -112,7 +112,7 @@ jobs:
     needs: strategy
     runs-on: ubuntu-latest
     concurrency:
-      group: preview-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}
+      group: submit-draft-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}
       cancel-in-progress: true
     if: ${{ needs.strategy.outputs.preview == 'true'}}
     strategy:
@@ -161,7 +161,7 @@ jobs:
     if: github.event_name == 'pull_request'
     needs:
       - strategy
-      - preview
+      - submit-draft
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB }}

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -26,15 +26,6 @@ on:
           The ID must also satisfy alphanumeric characters, dashes, and underscores.
         type: string
         default: '^([a-zA-Z0-9-]{36})$'
-      monorepo:
-        description: |
-          Indicate that this repository contains multiple projects that should be published.
-
-          For example, if you have multiple articles, or tutorials that should be previewed
-          and submitted when there are changes in the repository.
-        required: false
-        default: false
-        type: boolean
       path:
         description: |
           The root directory path(s) where the Curvenote CLI will be invoked.

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -13,7 +13,7 @@ on:
         description: |
           The kind of the submission
 
-          Available kinds are dependent on the venue and collection
+          Available kinds depend on the venue and collection
         required: true
         type: string
       id-pattern-regex:
@@ -30,7 +30,8 @@ on:
         description: |
           The root directory path(s) where the Curvenote CLI will be invoked.
           If `multiple` paths are being used, separate the `path` string with ','.
-          The paths can also be glob-like patterns (but only one `*`), for example:
+          The paths can also end in one wildcard `*`, which will match all individual
+          subfolders, for example:
 
           ```yaml
           path: my/project
@@ -44,23 +45,16 @@ on:
         type: string
       enforce-single-folder:
         description: |
-          When true, an error will be raised if a pull-request is touching multiple
-          different folders. This can either be `true` or a label string.
-          Multiple labels can be added with comma-separated values.
-
-          If labels are used to control this property, the pull request will only fail in
-          PRs with these labels.
-
-          This can be used in conjunction with the `preview-label`, for example, if they
-          are both `paper` then the PRs with those labels will be required to only make changes
-          in a single folder and will not be previewed if that condition fails.
-          However, you can add additional preview labels, e.g. `all-papers`, which will build
-          previews for all papers, as the single folder condition is not enforced for that label.
+          When true, an error will be raised if a pull request is touching multiple
+          different folders. It will also error if changes are made outside a folder
+          described in `path`.
         required: false
         default: 'false'
         type: string
       ref:
-        description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
+        description: |
+          The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow,
+          this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
         type: string
       comment:
         description: |
@@ -109,7 +103,7 @@ jobs:
     needs: strategy
     runs-on: ubuntu-latest
     concurrency:
-      group: submit-draft-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}-${{ matrix.working-directory }}
+      group: draft-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}-${{ matrix.working-directory }}
       cancel-in-progress: true
     if: ${{ needs.strategy.outputs.preview == 'true'}}
     strategy:

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -59,6 +59,14 @@ on:
         required: false
         default: 'false'
         type: string
+      label:
+        description: |
+          A pull-request label that indicates the submission should be run.
+          Multiple labels can be added with comma-separated values.
+
+          If no label is supplied, the submission will run on all PRs.
+        required: false
+        type: string
       ref:
         description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
         type: string
@@ -104,7 +112,7 @@ jobs:
           path: ${{ inputs.path }}
           enforce-single-folder: ${{ inputs.enforce-single-folder }}
           id-pattern-regex: ${{ inputs.id-pattern-regex }}
-          submit-label: true
+          submit-label: ${{ inputs.label || true }}
   check-and-submit:
     needs: strategy
     runs-on: ubuntu-latest

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       check: ${{ steps.build-strategy.outputs.check }}
-      preview: ${{ steps.build-strategy.outputs.preview }}
+      submit: ${{ steps.build-strategy.outputs.submit }}
       matrix: ${{ steps.build-strategy.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
@@ -116,6 +116,7 @@ jobs:
   check-and-submit:
     needs: strategy
     runs-on: ubuntu-latest
+    if: ${{ needs.strategy.outputs.submit == 'true'}}
     concurrency:
       group: submit-${{ github.head_ref }}-${{ matrix.working-directory }}
       cancel-in-progress: true

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -120,7 +120,8 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 1
       - uses: curvenote/actions/setup@main
-      - run: |
+      - name: Run curvenote check
+        run: |
           if [ -n "${{ inputs.collection }}" ]; then
             COLLECTION="--collection ${{ inputs.collection }}"
           fi

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -53,7 +53,7 @@ on:
         type: string
       label:
         description: |
-          A pull-request label that indicates the submission should be run.
+          A pull request label that indicates the submission should be run.
           Multiple labels can be added with comma-separated values.
 
           If no label is supplied, the submission will run on all PRs.

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -13,7 +13,7 @@ on:
         description: |
           The kind of the submission
 
-          Available kinds are dependent on the venue and collection
+          Available kinds depend on the venue and collection
         required: true
         type: string
       id-pattern-regex:
@@ -30,7 +30,8 @@ on:
         description: |
           The root directory path(s) where the Curvenote CLI will be invoked.
           If `multiple` paths are being used, separate the `path` string with ','.
-          The paths can also be glob-like patterns (but only one `*`), for example:
+          The paths can also end in one wildcard `*`, which will match all individual
+          subfolders, for example:
 
           ```yaml
           path: my/project
@@ -44,18 +45,9 @@ on:
         type: string
       enforce-single-folder:
         description: |
-          When true, an error will be raised if a pull-request is touching multiple
-          different folders. This can either be `true` or a label string.
-          Multiple labels can be added with comma-separated values.
-
-          If labels are used to control this property, the pull request will only fail in
-          PRs with these labels.
-
-          This can be used in conjunction with the `preview-label`, for example, if they
-          are both `paper` then the PRs with those labels will be required to only make changes
-          in a single folder and will not be previewed if that condition fails.
-          However, you can add additional preview labels, e.g. `all-papers`, which will build
-          previews for all papers, as the single folder condition is not enforced for that label.
+          When true, an error will be raised if a pull request is touching multiple
+          different folders. It will also error if changes are made outside a folder
+          described in `path`.
         required: false
         default: 'false'
         type: string
@@ -68,11 +60,13 @@ on:
         required: false
         type: string
       ref:
-        description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
+        description: |
+          The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow,
+          this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
         type: string
       comment:
         description: |
-          By default, the draft workflow will create a summary comment on the PR / commit. If the action file
+          By default, the submit workflow will create a summary comment on the PR / commit. If the action file
           does not grant sufficient permissions for this, the action will fail.
 
           Setting `comment: false` stops the workflow from attempting to comment, allowing the action to pass
@@ -96,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
           fetch-depth: 1
       - name: Get changed files
         id: changed-files
@@ -118,14 +112,14 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.strategy.outputs.submit == 'true'}}
     concurrency:
-      group: submit-${{ github.head_ref }}-${{ matrix.working-directory }}
+      group: submit-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}-${{ matrix.working-directory }}
       cancel-in-progress: true
     strategy:
       matrix: ${{fromJson(needs.strategy.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
           fetch-depth: 1
       - uses: curvenote/actions/setup@main
       - name: Run curvenote check

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -101,7 +101,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB }}
         with:
           changed-files: ${{ steps.changed-files.outputs.all_changed_files }}
-          monorepo: ${{ inputs.monorepo }}
           path: ${{ inputs.path }}
           enforce-single-folder: ${{ inputs.enforce-single-folder }}
           id-pattern-regex: ${{ inputs.id-pattern-regex }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -109,7 +109,7 @@ jobs:
     needs: strategy
     runs-on: ubuntu-latest
     concurrency:
-      group: submit-${{ github.head_ref }}
+      group: submit-${{ github.head_ref }}-${{ matrix.working-directory }}
       cancel-in-progress: true
     strategy:
       matrix: ${{fromJson(needs.strategy.outputs.matrix)}}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,159 @@
+name: submit
+on:
+  workflow_call:
+    inputs:
+      venue:
+        description: The site or venue that this project is being submitted to
+        required: true
+        type: string
+      collection:
+        description: The venue's collection that this collection is being submitted to
+        type: string
+      kind:
+        description: |
+          The kind of the submission
+
+          Available kinds are dependent on the venue and collection
+        required: true
+        type: string
+      id-pattern-regex:
+        description: |
+          A regular expression that all IDs must follow, by default this matches a UUID.
+
+          This can be used to enforce that all project IDs follow a specific pattern, such as,
+          the conference name + year.
+
+          The ID must also satisfy alphanumeric characters, dashes, and underscores.
+        type: string
+        default: '^([a-zA-Z0-9-]{36})$'
+      monorepo:
+        description: |
+          Indicate that this repository contains multiple projects that should be published.
+
+          For example, if you have multiple articles, or tutorials that should be previewed
+          and submitted when there are changes in the repository.
+        required: false
+        default: false
+        type: boolean
+      path:
+        description: |
+          The root directory path(s) where the Curvenote CLI will be invoked.
+          If `multiple` paths are being used, separate the `path` string with ','.
+          The paths can also be glob-like patterns (but only one `*`), for example:
+
+          ```yaml
+          path: my/project
+          path: my/paper, my/poster
+          path: papers/*, posters/*
+          ```
+
+          The default path is the root of the repository.
+        required: false
+        default: '.'
+        type: string
+      enforce-single-folder:
+        description: |
+          When true, an error will be raised if a pull-request is touching multiple
+          different folders. This can either be `true` or a label string.
+          Multiple labels can be added with comma-separated values.
+
+          If labels are used to control this property, the pull request will only fail in
+          PRs with these labels.
+
+          This can be used in conjunction with the `preview-label`, for example, if they
+          are both `paper` then the PRs with those labels will be required to only make changes
+          in a single folder and will not be previewed if that condition fails.
+          However, you can add additional preview labels, e.g. `all-papers`, which will build
+          previews for all papers, as the single folder condition is not enforced for that label.
+        required: false
+        default: 'false'
+        type: string
+      ref:
+        description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
+        type: string
+    secrets:
+      GITHUB:
+        description: GitHub API token (usually `env.GITHUB_TOKEN`)
+        required: true
+      CURVENOTE:
+        description: Curvenote API token (usually `secrets.CURVENOTE_TOKEN`)
+        required: true
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  strategy:
+    runs-on: ubuntu-latest
+    outputs:
+      check: ${{ steps.build-strategy.outputs.check }}
+      preview: ${{ steps.build-strategy.outputs.preview }}
+      matrix: ${{ steps.build-strategy.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          separator: ','
+      - id: build-strategy
+        uses: curvenote/actions/strategy@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB }}
+        with:
+          changed-files: ${{ steps.changed-files.outputs.all_changed_files }}
+          monorepo: ${{ inputs.monorepo }}
+          path: ${{ inputs.path }}
+          enforce-single-folder: ${{ inputs.enforce-single-folder }}
+          id-pattern-regex: ${{ inputs.id-pattern-regex }}
+          submit-label: true
+  check-and-submit:
+    needs: strategy
+    runs-on: ubuntu-latest
+    concurrency:
+      group: submit-${{ github.head_ref }}
+      cancel-in-progress: true
+    strategy:
+      matrix: ${{fromJson(needs.strategy.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+      - uses: curvenote/actions/setup@main
+      - run: |
+          if [ -n "${{ inputs.collection }}" ]; then
+            COLLECTION="--collection ${{ inputs.collection }}"
+          fi
+          curvenote check ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION
+        working-directory: ${{ matrix.working-directory }}
+        env:
+          CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
+      - uses: curvenote/actions/submit@main
+        env:
+          CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
+        with:
+          id: ${{ matrix.id }}
+          venue: ${{ inputs.venue }}
+          collection: ${{ inputs.collection }}
+          kind: ${{ inputs.kind }}
+          working-directory: ${{ matrix.working-directory }}
+          draft: false
+  summary:
+    needs:
+      - strategy
+      - check-and-submit
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB }}
+    steps:
+      - uses: curvenote/actions/submit-summary@main
+        id: summary
+        with:
+          matrix: '${{ needs.strategy.outputs.matrix }}'
+      - uses: curvenote/actions/upsert-comment@main
+        if: ${{ github.event.pull_request.number }}
+        with:
+          comment: '${{ steps.summary.outputs.comment }}'

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -62,6 +62,15 @@ on:
       ref:
         description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
         type: string
+      comment:
+        description: |
+          By default, the draft workflow will create a summary comment on the PR / commit. If the action file
+          does not grant sufficient permissions for this, the action will fail.
+
+          Setting `comment: false` stops the workflow from attempting to comment, allowing the action to pass
+          without write permissions.
+        default: true
+        type: boolean
     secrets:
       GITHUB:
         description: GitHub API token (usually `env.GITHUB_TOKEN`)
@@ -142,6 +151,7 @@ jobs:
         id: summary
         with:
           matrix: '${{ needs.strategy.outputs.matrix }}'
-      - uses: curvenote/actions/upsert-comment@main
+      - if: ${{ inputs.comment }}
+        uses: curvenote/actions/upsert-comment@main
         with:
           comment: '${{ steps.summary.outputs.comment }}'

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -78,9 +78,6 @@ on:
       CURVENOTE:
         description: Curvenote API token (usually `secrets.CURVENOTE_TOKEN`)
         required: true
-permissions:
-  contents: read
-  pull-requests: write
 jobs:
   strategy:
     runs-on: ubuntu-latest

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -26,15 +26,6 @@ on:
           The ID must also satisfy alphanumeric characters, dashes, and underscores.
         type: string
         default: '^([a-zA-Z0-9-]{36})$'
-      monorepo:
-        description: |
-          Indicate that this repository contains multiple projects that should be published.
-
-          For example, if you have multiple articles, or tutorials that should be previewed
-          and submitted when there are changes in the repository.
-        required: false
-        default: false
-        type: boolean
       path:
         description: |
           The root directory path(s) where the Curvenote CLI will be invoked.

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -152,6 +152,5 @@ jobs:
         with:
           matrix: '${{ needs.strategy.outputs.matrix }}'
       - uses: curvenote/actions/upsert-comment@main
-        if: ${{ github.event.pull_request.number }}
         with:
           comment: '${{ steps.summary.outputs.comment }}'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ jobs:
   publish:
     uses: curvenote/actions/.github/workflows/publish.yml@v1
     with:
-      monorepo: true
       id-pattern-regex: '^<MYJOURNAL-COLLECTION>-(?:[a-zA-Z0-9-_]{3,15})$'
       enforce-single-folder: true
       preview-label: paper
@@ -33,9 +32,6 @@ jobs:
 ```
 
 ### Options
-
-1. **`monorepo` (boolean)**
-   When `true` indicates that this repository contains multiple projects that should be published. For example, if you have multiple articles, or tutorials that should be previewed and submitted when there are changes in the repository.
 
 1. **`id-pattern-regex` (string - regex)**
    A regular expression that all IDs must follow, by default this matches a UUID.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@curvenote/actions",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "workspaces": [
     "strategy",
     "submit-summary"

--- a/strategy/src/index.ts
+++ b/strategy/src/index.ts
@@ -17,16 +17,9 @@ import {
     return;
   }
   const octokit = new Octokit({ auth: githubToken });
-  const monorepo = core.getInput('monorepo') === 'true';
   const paths = await resolvePaths('', core.getInput('path'));
   const { assignees, reviewers } = (await getPullRequestReviewers(octokit)) ?? {};
 
-  if (!monorepo && paths.length !== 1) {
-    core.setFailed(
-      'Cannot include multiple paths if the strategy is not a monorepo.\n\nEither set `monorepo: true` or set a single path (without glob-like patterns).',
-    );
-    return;
-  }
   const previewLabel = booleanOrLabels(core.getInput('preview-label'));
   const submitLabel = booleanOrLabels(core.getInput('submit-label'));
   const idPatternRegex = core.getInput('id-pattern-regex');
@@ -53,7 +46,6 @@ import {
   console.log(
     'Strategy Inputs:\n\n',
     {
-      monorepo,
       enforceSingleFolder,
       paths,
       pathIds,

--- a/strategy/src/index.ts
+++ b/strategy/src/index.ts
@@ -92,6 +92,7 @@ These files are outside of an allowed folder path:
 
   // Indicate whether to run the next jobs
   core.setOutput('preview', doPreview);
+  core.setOutput('submit', doSubmit);
   core.setOutput('check', true);
   // Set the build matrix
   core.setOutput(

--- a/strategy/src/utils.spec.ts
+++ b/strategy/src/utils.spec.ts
@@ -119,6 +119,14 @@ describe('utility tests', () => {
       unknownChangedFiles: ['posters/temp.tex', '.git/temp.bin'],
     });
   });
+  it('filterPathsAndIdentifyUnknownChanges - path . allows all changes', () => {
+    expect(
+      filterPathsAndIdentifyUnknownChanges(['p'], ['posters/temp.tex', '.git/temp.bin']),
+    ).toEqual({
+      filteredPaths: [],
+      unknownChangedFiles: ['posters/temp.tex', '.git/temp.bin'],
+    });
+  });
 
   it('getIdsFromPaths', async () => {
     memfs.vol.fromJSON({

--- a/strategy/src/utils.spec.ts
+++ b/strategy/src/utils.spec.ts
@@ -119,12 +119,20 @@ describe('utility tests', () => {
       unknownChangedFiles: ['posters/temp.tex', '.git/temp.bin'],
     });
   });
-  it('filterPathsAndIdentifyUnknownChanges - path . allows all changes', () => {
+  it('filterPathsAndIdentifyUnknownChanges - substring does not match path', () => {
     expect(
       filterPathsAndIdentifyUnknownChanges(['p'], ['posters/temp.tex', '.git/temp.bin']),
     ).toEqual({
       filteredPaths: [],
       unknownChangedFiles: ['posters/temp.tex', '.git/temp.bin'],
+    });
+  });
+  it('filterPathsAndIdentifyUnknownChanges - path . allows all changes', () => {
+    expect(
+      filterPathsAndIdentifyUnknownChanges(['.'], ['posters/temp.tex', '.git/temp.bin']),
+    ).toEqual({
+      filteredPaths: ['.'],
+      unknownChangedFiles: [],
     });
   });
 

--- a/strategy/src/utils.ts
+++ b/strategy/src/utils.ts
@@ -112,6 +112,10 @@ export function filterPathsAndIdentifyUnknownChanges(
     return !allowedPaths.some((allowed) => pathStartsWith(changed, allowed));
   });
 
+  // If '.' path is allowed, all changes are valid
+  if (allowedPaths.includes('.')) {
+    return { filteredPaths: [...filteredPaths, '.'], unknownChangedFiles: [] };
+  }
   return { filteredPaths, unknownChangedFiles };
 }
 

--- a/strategy/src/utils.ts
+++ b/strategy/src/utils.ts
@@ -64,6 +64,19 @@ export async function resolvePaths(baseDir: string, pattern: string): Promise<st
 }
 
 /**
+ * Check if 'fullPath' path starts with 'basePath' path
+ *
+ * This only matches full directory names, e.g.
+ *
+ * pathStartsWith('papers/my-paper.md', 'pa') returns false
+ *
+ */
+function pathStartsWith(fullPath: string, basePath: string) {
+  const fullSliced = fullPath.split('/').slice(0, basePath.split('/').length).join('/');
+  return fullSliced === basePath;
+}
+
+/**
  * Filter the paths by the changed files, and mention any unknown changed files.
  *
  * @param allowedPaths The directories that are expected to have changes in them
@@ -89,14 +102,14 @@ export function filterPathsAndIdentifyUnknownChanges(
   const uniqueChangedPaths = Array.from(new Set(changedPaths));
 
   // Filter allowedPaths that are included in the changedPaths
-  const filteredPaths = allowedPaths.filter((allowed) =>
-    uniqueChangedPaths.some((changed) => changed.startsWith(allowed)),
-  );
+  const filteredPaths = allowedPaths.filter((allowed) => {
+    return uniqueChangedPaths.some((changed) => pathStartsWith(changed, allowed));
+  });
 
   // Identify changed files that are outside the specified paths
   const unknownChangedFiles = changedFiles.filter((changed) => {
     // Check if this file's base path does not start with any of the paths
-    return !allowedPaths.some((allowed) => changed.startsWith(allowed));
+    return !allowedPaths.some((allowed) => pathStartsWith(changed, allowed));
   });
 
   return { filteredPaths, unknownChangedFiles };

--- a/submit-summary/src/index.ts
+++ b/submit-summary/src/index.ts
@@ -84,7 +84,10 @@ function reportSummaryMessage(report: Report | undefined, buildUrl: string) {
 | :--- | :--- | :--- | :--- |
 ${submitLogs.map(({ data, info }) => `| **${info['working-directory']}** | 🔍 [Inspect](${data.buildUrl}) | ${reportSummaryMessage(data.report, data.buildUrl)} | ${formatDateUTC(data.submissionVersion.date_created)} |`).join('\n')}
 `;
-  console.log(table);
+  console.log('Summary:');
+  submitLogs.forEach(({ data, info }) => {
+    console.log(`${info['working-directory']} => ${data.buildUrl}`);
+  });
   core.setOutput('comment', table);
 })().catch((err) => {
   core.error(err);

--- a/submit-summary/src/index.ts
+++ b/submit-summary/src/index.ts
@@ -84,6 +84,7 @@ function reportSummaryMessage(report: Report | undefined, buildUrl: string) {
 | :--- | :--- | :--- | :--- |
 ${submitLogs.map(({ data, info }) => `| **${info['working-directory']}** | 🔍 [Inspect](${data.buildUrl}) | ${reportSummaryMessage(data.report, data.buildUrl)} | ${formatDateUTC(data.submissionVersion.date_created)} |`).join('\n')}
 `;
+  console.log(table);
   core.setOutput('comment', table);
 })().catch((err) => {
   core.error(err);

--- a/upsert-comment/README.md
+++ b/upsert-comment/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Streamlines the process of inserting or updating a comment on pull requests (PRs) within GitHub repositories. It allows for dynamic insertion or update of comments based on the results of build processes or any other automated workflow steps. This action can be particularly useful for providing feedback, results, or notifications directly within the context of a PR review process.
+Streamlines the process of inserting or updating a comment on pull requests (PRs) within GitHub repositories. It allows for dynamic insertion or update of comments based on the results of build processes or any other automated workflow steps. This action can be particularly useful for providing feedback, results, or notifications directly within the context of a PR review process. If this action is run outside the context of a PR, it will make a comment on the commit.
 
 ## Features
 
@@ -47,7 +47,7 @@ permissions:
 The action operates in a composite run steps mode and includes the following steps:
 
 1. **Find Comment:** Initially, it attempts to find an existing comment in the PR that matches the given criteria (issue number, comment author, and body includes the specified title).
-2. **Create Comment:** If no existing comment matches the criteria, a new comment is created in the pull request with the provided title and body.
+2. **Create Comment:** If no existing comment matches the criteria, a new comment is created in the pull request with the provided title and body. If there is no PR at all, a comment is created on the current commit.
 3. **Update Comment:** If an existing comment is found, it is updated with the new content, replacing the old comment entirely.
 
 ## Support

--- a/upsert-comment/action.yml
+++ b/upsert-comment/action.yml
@@ -1,5 +1,5 @@
 name: Comment based on build results
-description: Add a comment to the PR
+description: Add a comment to the PR or commit
 author: Curvenote Inc.
 branding:
   icon: package
@@ -14,15 +14,16 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Find Comment
+    - name: Find PR Comment
+      if: ${{ github.event.pull_request.number }}
       uses: peter-evans/find-comment@v3
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
         body-includes: ${{ inputs.title }}
-    - name: Create comment
-      if: steps.fc.outputs.comment-id == ''
+    - name: Create PR comment
+      if: ${{ github.event.pull_request.number && steps.fc.outputs.comment-id == '' }}
       uses: peter-evans/create-or-update-comment@v4
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -30,12 +31,20 @@ runs:
           **${{ inputs.title }}**
 
           ${{ inputs.comment }}
-    - name: Update comment
-      if: steps.fc.outputs.comment-id != ''
+    - name: Update PR comment
+      if: ${{ github.event.pull_request.number && steps.fc.outputs.comment-id != '' }}
       uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         edit-mode: replace
+        body: |
+          **${{ inputs.title }}**
+
+          ${{ inputs.comment }}
+    - name: Create Commit comment
+      if: ${{ !github.event.pull_request.number }}
+      uses: peter-evans/commit-comment@v3
+      with:
         body: |
           **${{ inputs.title }}**
 


### PR DESCRIPTION
- [x] Add "draft" workflow
- [x] Add "submit" workflow
  - These replace the single, overloaded "publish" workflow
- [x] Eliminate `monorepo` input - `path` and `enforce-single-folder` can define the monorepo workflow on their own
- [x] Remove complexity around `preview-label` and `submit-label` for new workflows
  - There is still `label` on "submit" workflow, but previews are just always created if the action is triggered
- [x] Allow disabling PR comment (for reduced permissions on the action)
- [x] Fix the default path workflow where the CLI is invoked at the root of the repo
- [x] Update readme with relevant examples of a few different usecases 