### PR TITLE
Only error on invalid ids for changed paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@curvenote/actions",
   "private": true,
-  "version": "1.0.6",
+  "version": "1.0.7",
   "workspaces": [
     "strategy",
     "submit-summary"

--- a/strategy/src/index.ts
+++ b/strategy/src/index.ts
@@ -64,7 +64,12 @@ import {
     '\n\n',
   );
 
-  const { messages, valid: idsAreValid } = ensureUniqueAndValidIds(pathIds, idPatternRegex);
+  const filteredPathIds: Record<string, string | null> = {};
+  filteredPaths.forEach((path) => {
+    filteredPathIds[path] = pathIds[path];
+  });
+
+  const { messages, valid: idsAreValid } = ensureUniqueAndValidIds(filteredPathIds, idPatternRegex);
 
   if (!idsAreValid) {
     core.setFailed(


### PR DESCRIPTION
For example - this should not fail - the user who changed one project shouldn't be impacted by an error in another project:

![image](https://github.com/user-attachments/assets/5bda6e17-e032-4299-8d55-628ff5135109)
