### PR TITLE
Separate check and submit jobs

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -158,9 +158,11 @@ jobs:
         env:
           CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
   summary:
+    if: ${{ always() }}
     needs:
       - strategy
       - submit-draft
+      - check
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -111,10 +111,36 @@ jobs:
           enforce-single-folder: ${{ inputs.enforce-single-folder }}
           id-pattern-regex: ${{ inputs.id-pattern-regex }}
           submit-label: ${{ inputs.label || true }}
-  check-and-submit:
+  check:
     needs: strategy
     runs-on: ubuntu-latest
-    if: ${{ needs.strategy.outputs.submit == 'true'}}
+    if: ${{ needs.strategy.outputs.check == 'true'}}
+    strategy:
+      matrix: ${{fromJson(needs.strategy.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
+          fetch-depth: 1
+      - uses: curvenote/actions/setup@main
+        with:
+          typst: false
+          images: false
+      - name: Run curvenote check
+        run: |
+          if [ -n "${{ inputs.collection }}" ]; then
+            COLLECTION="--collection ${{ inputs.collection }}"
+          fi
+          curvenote check ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION
+        working-directory: ${{ matrix.working-directory }}
+        env:
+          CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
+  submit:
+    needs:
+      - strategy
+      - check
+    runs-on: ubuntu-latest
+    if: ${{ needs.strategy.outputs.submit == 'true' && (!failure() || !inputs.strict) }}
     concurrency:
       group: submit-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}-${{ matrix.working-directory }}
       cancel-in-progress: true
@@ -126,17 +152,7 @@ jobs:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
           fetch-depth: 1
       - uses: curvenote/actions/setup@main
-      - name: Run curvenote check
-        run: |
-          if [ -n "${{ inputs.collection }}" ]; then
-            COLLECTION="--collection ${{ inputs.collection }}"
-          fi
-          curvenote check ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION
-        working-directory: ${{ matrix.working-directory }}
-        env:
-          CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
-      - if: ${{ !failure() || !inputs.strict }}
-        uses: curvenote/actions/submit@main
+      - uses: curvenote/actions/submit@main
         env:
           CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
         with:
@@ -150,7 +166,8 @@ jobs:
     if: ${{ always() }}
     needs:
       - strategy
-      - check-and-submit
+      - check
+      - submit
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@curvenote/actions",
   "private": true,
-  "version": "1.0.7",
+  "version": "1.0.8",
   "workspaces": [
     "strategy",
     "submit-summary"


### PR DESCRIPTION
In the submit workflow, checks can fail and a submission will still happen unless `strict` is `true`. This worked before and still works after this PR.

However, previously, `check-and-submit` was one `job` - that mean it looked a little funny when the checks failed, marking the job as failed, but the submit still happened, hidden away behind a ❌.

Now, check and submit are separate jobs (similar to the draft workflow). As before, if the check fails, the submission will still happen, but it is much clearer: the check job will have a ❌ and the submit job will have a ✅. If `strict: true` and the checks fail, the submit job will clearly not run.

Additionally, with this PR, the `summary` job always runs, both for the draft and the submit workflows, regardless of failures. This just provides a little more feedback to the user in the github comments if nothing was submitted to the journal.