### PR TITLE
Feat/publish on submit

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -115,6 +115,7 @@ jobs:
       cancel-in-progress: true
     if: ${{ needs.strategy.outputs.preview == 'true'}}
     strategy:
+      fail-fast: false
       matrix: ${{fromJson(needs.strategy.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4
@@ -137,6 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.strategy.outputs.check == 'true'}}
     strategy:
+      fail-fast: false
       matrix: ${{fromJson(needs.strategy.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -126,6 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.strategy.outputs.check == 'true'}}
     strategy:
+      fail-fast: false
       matrix: ${{fromJson(needs.strategy.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4
@@ -155,6 +156,7 @@ jobs:
       group: submit-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}-${{ matrix.working-directory }}
       cancel-in-progress: true
     strategy:
+      fail-fast: false
       matrix: ${{fromJson(needs.strategy.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -77,6 +77,16 @@ on:
         description: Stop submission if checks fail.
         default: false
         type: boolean
+      publish:
+        description: |
+          Immediately publish a submission after successful submit action. This bypasses any
+          manual review of the submission preview. The CURVENOTE token must have sufficient
+          permissions to publish a submission.
+
+          This flag should not be used for venues where editors accept submissions from
+          external authors, as it gives authors complete control over published content.
+        default: false
+        type: boolean
     secrets:
       GITHUB:
         description: GitHub API token (usually `env.GITHUB_TOKEN`)
@@ -162,6 +172,7 @@ jobs:
           kind: ${{ inputs.kind }}
           working-directory: ${{ matrix.working-directory }}
           draft: false
+          publish: ${{ inputs.publish }}
   summary:
     if: ${{ always() }}
     needs:

--- a/submit/action.yml
+++ b/submit/action.yml
@@ -25,6 +25,9 @@ inputs:
   draft:
     description: Flag to indicate if the submission should be a draft
     default: false
+  publish:
+    description: Flag to indicate if the submission should be immediately published without additional review
+    default: false
 runs:
   using: composite
   steps:
@@ -39,6 +42,11 @@ runs:
           COLLECTION="--collection ${{ inputs.collection }}"
         fi
         curvenote submit ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION $DRAFT -y
+    - name: Publish submission
+      if: ${{ inputs.publish && !inputs.draft }}
+      shell: bash
+      run: |
+        curvenote sub publish ${{ inputs.venue }}
     - name: Upload Curvenote Logs
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
For some smaller `venues`, the authors also control editorial duties. In these cases, when they make a new submission, they may know they are happy with it and wish to immediately publish, without manual intervention from the admin dashboard or command line.

This adds a new `publish` option to the `submit.yml` action which, if `true`, will immediately publish the submission to the venue. This requires a curvenote token with publish permissions.

This flag should not be used for venues where editors accept submissions from external authors, as it gives authors complete control over published content.

This addresses #28 (though there is still room for a separate action to _only_ publish an existing submisison)

I also added a small fix I hope will address the matrix cancelling issues discussed in #26 