### PR TITLE
🔒 Try SHAs for external deps

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -94,7 +94,7 @@ jobs:
           fetch-depth: 1
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@0b975f61488402a699abcebd6a1e25924cf85218
         with:
           separator: ','
       - id: build-strategy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,7 +119,7 @@ jobs:
           fetch-depth: 1
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@0b975f61488402a699abcebd6a1e25924cf85218
         with:
           separator: ','
       - id: build-strategy

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -108,7 +108,7 @@ jobs:
           fetch-depth: 1
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@0b975f61488402a699abcebd6a1e25924cf85218
         with:
           separator: ','
       - id: build-strategy

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@curvenote/actions",
   "private": true,
-  "version": "1.0.10",
+  "version": "1.0.11",
   "workspaces": [
     "strategy",
     "submit-summary"

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
     - name: Install Typst for PDF builds
       if: ${{ inputs.typst == 'true' }}
-      uses: typst-community/setup-typst@ed0dd8f60af43a3b8a881db89ef24b020674ba85
+      uses: typst-community/setup-typst@468250b312a80ba1ce98072d08f4d20cc49d268c
     - name: Install image transformation utilities
       if: ${{ inputs.images == 'true' }}
       shell: bash

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
     - name: Install Typst for PDF builds
       if: ${{ inputs.typst == 'true' }}
-      uses: typst-community/setup-typst@v3
+      uses: typst-community/setup-typst@ed0dd8f60af43a3b8a881db89ef24b020674ba85
     - name: Install image transformation utilities
       if: ${{ inputs.images == 'true' }}
       shell: bash

--- a/upsert-comment/action.yml
+++ b/upsert-comment/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Find PR Comment
       if: ${{ github.event.pull_request.number }}
-      uses: peter-evans/find-comment@v3
+      uses: peter-evans/find-comment@60c57613a233a2143853d3f68874167868b5d040
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -24,7 +24,7 @@ runs:
         body-includes: ${{ inputs.title }}
     - name: Create PR comment
       if: ${{ github.event.pull_request.number && steps.fc.outputs.comment-id == '' }}
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@dec9d02d7ba794da3485751abf67551b0724c66b
       with:
         issue-number: ${{ github.event.pull_request.number }}
         body: |
@@ -33,7 +33,7 @@ runs:
           ${{ inputs.comment }}
     - name: Update PR comment
       if: ${{ github.event.pull_request.number && steps.fc.outputs.comment-id != '' }}
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@dec9d02d7ba794da3485751abf67551b0724c66b
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         edit-mode: replace
@@ -43,7 +43,7 @@ runs:
           ${{ inputs.comment }}
     - name: Create Commit comment
       if: ${{ !github.event.pull_request.number }}
-      uses: peter-evans/commit-comment@v3
+      uses: peter-evans/commit-comment@1d732d08f4ceed8b5960ae40d4206620a3b8d38f
       with:
         body: |
           **${{ inputs.title }}**


### PR DESCRIPTION
This pins all external dependencies to SHAs. This means we must manually change the SHA if we want to consume updates, but it protects us from supply chain attacks, as recently occurred with tj-actions. Maybe worth a try?