### PR TITLE
🐛 Debug option and 🧼 Allow unchanged folders

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -51,6 +51,15 @@ on:
         required: false
         default: 'false'
         type: string
+      include-unchanged:
+        description: |
+          By default, the strategy will only identify folders with changes and run the action
+          on those. Unchanged folders will be ignored.
+
+          However, if `include-unchanged` is `true`, the action will be run under all folders
+          under `path`
+        required: false
+        default: false
       label:
         description: |
           A pull request label that indicates the preview should be run.
@@ -113,6 +122,7 @@ jobs:
           enforce-single-folder: ${{ inputs.enforce-single-folder }}
           id-pattern-regex: ${{ inputs.id-pattern-regex }}
           preview-label: ${{ inputs.label || true }}
+          include-unchanged: ${{ inputs.include-unchanged }}
   submit-draft:
     needs: strategy
     runs-on: ubuntu-latest

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -59,7 +59,8 @@ on:
           However, if `include-unchanged` is `true`, the action will be run under all folders
           under `path`
         required: false
-        default: false
+        default: 'false'
+        type: string
       label:
         description: |
           A pull request label that indicates the preview should be run.

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -59,6 +59,12 @@ on:
           If no label is supplied, the preview will run on all PRs.
         required: false
         type: string
+      debug:
+        description: |
+          Run curvenote commands in debug mode for verbose log messages
+        required: false
+        default: 'false'
+        type: string
       ref:
         description: |
           The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow,
@@ -131,6 +137,7 @@ jobs:
           venue: ${{ inputs.venue }}
           collection: ${{ inputs.collection }}
           kind: ${{ inputs.kind }}
+          debug: ${{ inputs.debug }}
           working-directory: ${{ matrix.working-directory }}
           draft: true
   check:
@@ -152,10 +159,13 @@ jobs:
       # Note, the collection shouldn't be necessary:
       - name: Run curvenote check
         run: |
+          if [ "${{ inputs.debug }}" = "true" ]; then
+            DEBUG="-d"
+          fi
           if [ -n "${{ inputs.collection }}" ]; then
             COLLECTION="--collection ${{ inputs.collection }}"
           fi
-          curvenote check ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION -d
+          curvenote check ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION $DEBUG
         working-directory: ${{ matrix.working-directory }}
         env:
           CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -179,7 +179,7 @@ jobs:
           if [ -n "${{ inputs.collection }}" ]; then
             COLLECTION="--collection ${{ inputs.collection }}"
           fi
-          curvenote check ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION -d
+          curvenote check ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION
         working-directory: ${{ matrix.working-directory }}
         env:
           CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -59,6 +59,12 @@ on:
           If no label is supplied, the submission will run on all PRs.
         required: false
         type: string
+      debug:
+        description: |
+          Run curvenote commands in debug mode for verbose log messages
+        required: false
+        default: 'false'
+        type: string
       ref:
         description: |
           The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow,
@@ -139,10 +145,13 @@ jobs:
           images: false
       - name: Run curvenote check
         run: |
+          if [ "${{ inputs.debug }}" = "true" ]; then
+            DEBUG="-d"
+          fi
           if [ -n "${{ inputs.collection }}" ]; then
             COLLECTION="--collection ${{ inputs.collection }}"
           fi
-          curvenote check ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION -d
+          curvenote check ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION $DEBUG
         working-directory: ${{ matrix.working-directory }}
         env:
           CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
@@ -172,6 +181,7 @@ jobs:
           venue: ${{ inputs.venue }}
           collection: ${{ inputs.collection }}
           kind: ${{ inputs.kind }}
+          debug: ${{ inputs.debug }}
           working-directory: ${{ matrix.working-directory }}
           draft: false
           publish: ${{ inputs.publish }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -59,7 +59,8 @@ on:
           However, if `include-unchanged` is `true`, the action will be run under all folders
           under `path`
         required: false
-        default: false
+        default: 'false'
+        type: string
       label:
         description: |
           A pull request label that indicates the submission should be run.

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -51,6 +51,15 @@ on:
         required: false
         default: 'false'
         type: string
+      include-unchanged:
+        description: |
+          By default, the strategy will only identify folders with changes and run the action
+          on those. Unchanged folders will be ignored.
+
+          However, if `include-unchanged` is `true`, the action will be run under all folders
+          under `path`
+        required: false
+        default: false
       label:
         description: |
           A pull request label that indicates the submission should be run.
@@ -127,6 +136,7 @@ jobs:
           enforce-single-folder: ${{ inputs.enforce-single-folder }}
           id-pattern-regex: ${{ inputs.id-pattern-regex }}
           submit-label: ${{ inputs.label || true }}
+          include-unchanged: ${{ inputs.include-unchanged }}
   check:
     needs: strategy
     runs-on: ubuntu-latest

--- a/strategy/action.yml
+++ b/strategy/action.yml
@@ -79,6 +79,15 @@ inputs:
       conditions are satisfied.
     required: false
     default: ready
+  include-unchanged:
+    description: |
+      By default, the strategy will only identify folders with changes and run the action
+      on those. Unchanged folders will be ignored.
+
+      However, if `include-unchanged` is `true`, the action will be run under all folders
+      under `path`
+    required: false
+    default: false
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/strategy/src/index.ts
+++ b/strategy/src/index.ts
@@ -18,6 +18,7 @@ import {
   }
   const octokit = new Octokit({ auth: githubToken });
   const paths = await resolvePaths('', core.getInput('path'));
+  const includeUnchanged = core.getInput('include-unchanged') === 'true';
   const { assignees, reviewers } = (await getPullRequestReviewers(octokit)) ?? {};
 
   const previewLabel = booleanOrLabels(core.getInput('preview-label'));
@@ -41,6 +42,7 @@ import {
   const { filteredPaths, unknownChangedFiles } = filterPathsAndIdentifyUnknownChanges(
     paths,
     changedFiles,
+    includeUnchanged,
   );
 
   console.log(

--- a/submit/action.yml
+++ b/submit/action.yml
@@ -25,7 +25,7 @@ inputs:
   draft:
     description: Flag to indicate if the submission should be a draft
     default: false
-  draft:
+  debug:
     description: Flag to indicate if the curvenote commands should run in debug mode
     default: false
   publish:

--- a/submit/action.yml
+++ b/submit/action.yml
@@ -25,6 +25,9 @@ inputs:
   draft:
     description: Flag to indicate if the submission should be a draft
     default: false
+  draft:
+    description: Flag to indicate if the curvenote commands should run in debug mode
+    default: false
   publish:
     description: |
       Flag to indicate if the submission should be immediately published without additional review
@@ -38,13 +41,16 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
+        if [ "${{ inputs.debug }}" = "true" ]; then
+          DEBUG="-d"
+        fi
         if [ "${{ inputs.draft }}" = "true" ]; then
           DRAFT="--draft"
         fi
         if [ -n "${{ inputs.collection }}" ]; then
           COLLECTION="--collection ${{ inputs.collection }}"
         fi
-        curvenote submit ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION $DRAFT -y -d
+        curvenote submit ${{ inputs.venue }} --kind "${{ inputs.kind }}" $COLLECTION $DRAFT $DEBUG -y
     - name: Publish submission
       if: ${{ inputs.publish == 'true' && !(inputs.draft == 'true') }}
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
# Change 1: 🐛 Make debug mode an option

As a quick-fix, I previously made all `curvenote` commands run in debug mode. This made the logs much less manageable when debug was not needed (i.e. almost all the time).

Now, you can put `debug: true` in your workflow, but otherwise curvenote does not run in debug mode.

This does a better job at addressing #36

# Change 2: 🧼 Allow running the action on unchanged folders

This action may be set up as a batch dispatch action, e.g. to "publish all" - In cases like that, we shouldn't require changes to every folder.

This PR adds an option `include-unchanged` - if `true`, the action will run in all folders discovered under `path`.

This addresses #32