### PR TITLE
Update Curvenote installation to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@curvenote/actions",
   "private": true,
-  "version": "1.0.16",
+  "version": "1.0.17",
   "workspaces": [
     "strategy",
     "submit-summary"

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         node-version: 20.x
     - name: Install Curvenote
-      run: npm install -g curvenote
+      run: npm install -g curvenote@latest
       shell: bash
     - name: Install Typst for PDF builds
       if: ${{ inputs.typst == 'true' }}


### PR DESCRIPTION
It explicitly installs the latest tag instead of just having it unpinned, which you should usually do what we want, but also gives us an additional level of control in terms of what gets pulled in on CI because we can move this latest tag to avoid issues on npm. 