### PR TITLE
🚶 Add path as option to push workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,6 +26,10 @@ on:
         required: false
         default: 'true'
         type: string
+      path:
+        description: Repository subdirectory with work content
+        required: false
+        type: string
     secrets:
       CURVENOTE:
         description: Curvenote API token (usually `secrets.CURVENOTE_TOKEN`)
@@ -46,6 +50,9 @@ jobs:
         env:
           CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
         run: |
+          if [ -n "${{ inputs.path }}" ]; then
+            cd "${{ inputs.path }}"
+          fi
           if [ "${{ inputs.debug }}" = "true" ]; then
             DEBUG="-d"
           fi
@@ -56,6 +63,9 @@ jobs:
         env:
           CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
         run: |
+          if [ -n "${{ inputs.path }}" ]; then
+            cd "${{ inputs.path }}"
+          fi
           if [ "${{ inputs.debug }}" = "true" ]; then
             DEBUG="-d"
           fi
@@ -66,6 +76,9 @@ jobs:
         env:
           CURVENOTE_TOKEN: ${{ secrets.CURVENOTE }}
         run: |
+          if [ -n "${{ inputs.path }}" ]; then
+            cd "${{ inputs.path }}"
+          fi
           if [ "${{ inputs.debug }}" = "true" ]; then
             DEBUG="-d"
           fi

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Of course, this workflow could also be triggered `on` push to `main` or even set
 
 # Work Pushing
 
-Currently, pushing a Work to Curvenote is a simpler action than journal submissions. Pushing your work will upload a version to the Curvenote platform, which may then subsequently be used for journal submissions or site landing content. The push action currently only acts on the root folder of your repository. A simple usage of this action to push on merge to main looks like:
+Currently, pushing a Work to Curvenote is a simpler action than journal submissions. Pushing your work will upload a version to the Curvenote platform, which may then subsequently be used for journal submissions or site landing content. By default, the push action acts at the repository root; use the optional `path` input to run from a subdirectory instead. A simple usage of this action to push on merge to main looks like:
 
 ```yaml
 name: curvenote push
@@ -239,4 +239,7 @@ These optional inputs may be used with the `draft`, `submit`, or `push` actions.
 
 1. **`images` (string)**
    When `true`, installs image conversion tooling (for example Inkscape and ImageMagick) used by the build. Set to `false` to skip. Default is `true`.
+
+1. **`path` (string)** — `push` only
+   Repository subdirectory the push action acts. If omitted, it will run at the repository root.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@curvenote/actions",
   "private": true,
-  "version": "1.0.17",
+  "version": "1.0.18",
   "workspaces": [
     "strategy",
     "submit-summary"


### PR DESCRIPTION
This PR lets you define landing content in a subdirectory of your repository. Use the `path` input on the `push` workflow.