### PR TITLE
⚙️ Install pdf deps on check step

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -196,8 +196,9 @@ jobs:
           fetch-depth: 1
       - uses: curvenote/actions/setup@main
         with:
-          typst: false
-          images: false
+          typst: ${{ inputs.typst }}
+          fonts: ${{ inputs.fonts }}
+          images: ${{ inputs.images }}
       # Note, the collection shouldn't be necessary:
       - name: Run curvenote check
         run: |

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -179,8 +179,9 @@ jobs:
           fetch-depth: 1
       - uses: curvenote/actions/setup@main
         with:
-          typst: false
-          images: false
+          typst: ${{ inputs.typst }}
+          fonts: ${{ inputs.fonts }}
+          images: ${{ inputs.images }}
       - name: Run curvenote check
         run: |
           if [ "${{ inputs.debug }}" = "true" ]; then

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@curvenote/actions",
   "private": true,
-  "version": "1.0.18",
+  "version": "1.0.19",
   "workspaces": [
     "strategy",
     "submit-summary"


### PR DESCRIPTION
We now have an "exports exist" check that ensures exports build correctly. This means we need pdf dependencies in the `check` stage (if we have them for the `submit` stage).