### PR TITLE
📋 Read changed files from json file rather than comma-separated arg

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -100,6 +100,18 @@ on:
           without write permissions.
         default: true
         type: boolean
+      comment-title:
+        description: |
+          The title of the summary comment, which also identifies the comment to update on
+          subsequent runs.
+
+          If a single workflow file calls this workflow more than once, each job must set a
+          distinct `comment-title`, otherwise the jobs will overwrite each other's comment.
+
+          No title may be a prefix of another, as comments are matched by looking for the
+          title within the comment body.
+        default: Curvenote Preview
+        type: string
       typst:
         description: |
           When true (default), use the full CLI image with Typst and fonts.
@@ -248,4 +260,5 @@ jobs:
       - if: ${{ inputs.comment }}
         uses: curvenote/actions/upsert-comment@main
         with:
+          title: ${{ inputs.comment-title }}
           comment: '${{ steps.summary.outputs.comment }}'

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -146,13 +146,16 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
         with:
-          separator: ','
+          json: 'true'
+          write_output_files: 'true'
+          safe_output: 'false'
+          output_dir: ${{ runner.temp }}/changed-files
       - id: build-strategy
         uses: curvenote/actions/strategy@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB }}
         with:
-          changed-files: ${{ steps.changed-files.outputs.all_changed_files }}
+          changed-files-json: ${{ runner.temp }}/changed-files/all_changed_files.json
           path: ${{ inputs.path }}
           exclude: ${{ inputs.exclude }}
           enforce-single-folder: ${{ inputs.enforce-single-folder }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,6 +95,18 @@ on:
       ref:
         description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
         type: string
+      comment-title:
+        description: |
+          The title of the summary comment, which also identifies the comment to update on
+          subsequent runs.
+
+          If a single workflow file calls this workflow more than once, each job must set a
+          distinct `comment-title`, otherwise the jobs will overwrite each other's comment.
+
+          No title may be a prefix of another, as comments are matched by looking for the
+          title within the comment body.
+        default: Curvenote Preview
+        type: string
     secrets:
       GITHUB:
         description: GitHub API token (usually `env.GITHUB_TOKEN`)
@@ -205,4 +217,5 @@ jobs:
           matrix: '${{ needs.strategy.outputs.matrix }}'
       - uses: curvenote/actions/upsert-comment@main
         with:
+          title: ${{ inputs.comment-title }}
           comment: '${{ steps.summary.outputs.comment }}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,13 +123,16 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
         with:
-          separator: ','
+          json: 'true'
+          write_output_files: 'true'
+          safe_output: 'false'
+          output_dir: ${{ runner.temp }}/changed-files
       - id: build-strategy
         uses: curvenote/actions/strategy@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB }}
         with:
-          changed-files: ${{ steps.changed-files.outputs.all_changed_files }}
+          changed-files-json: ${{ runner.temp }}/changed-files/all_changed_files.json
           monorepo: ${{ inputs.monorepo }}
           path: ${{ inputs.path }}
           enforce-single-folder: ${{ inputs.enforce-single-folder }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -160,13 +160,16 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
         with:
-          separator: ','
+          json: 'true'
+          write_output_files: 'true'
+          safe_output: 'false'
+          output_dir: ${{ runner.temp }}/changed-files
       - id: build-strategy
         uses: curvenote/actions/strategy@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB }}
         with:
-          changed-files: ${{ steps.changed-files.outputs.all_changed_files }}
+          changed-files-json: ${{ runner.temp }}/changed-files/all_changed_files.json
           path: ${{ inputs.path }}
           exclude: ${{ inputs.exclude }}
           enforce-single-folder: ${{ inputs.enforce-single-folder }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -100,6 +100,18 @@ on:
           without write permissions.
         default: true
         type: boolean
+      comment-title:
+        description: |
+          The title of the summary comment, which also identifies the comment to update on
+          subsequent runs.
+
+          If a single workflow file calls this workflow more than once, each job must set a
+          distinct `comment-title`, otherwise the jobs will overwrite each other's comment.
+
+          No title may be a prefix of another, as comments are matched by looking for the
+          title within the comment body.
+        default: Curvenote Preview
+        type: string
       strict:
         description: Stop submission if checks fail.
         default: false
@@ -264,4 +276,5 @@ jobs:
       - if: ${{ inputs.comment }}
         uses: curvenote/actions/upsert-comment@main
         with:
+          title: ${{ inputs.comment-title }}
           comment: '${{ steps.summary.outputs.comment }}'

--- a/README.md
+++ b/README.md
@@ -242,3 +242,28 @@ These optional inputs may be used with the `draft`, `submit`, or `push` actions.
 1. **`path` (string)** — `push` only
    Repository subdirectory the push action acts. If omitted, it will run at the repository root.
 
+1. **`comment-title` (string)** — `draft` and `submit` only
+   The title of the summary comment, shown in bold at the top. The title also identifies the comment, so that later runs update it in place rather than adding a new one. Default is `Curvenote Preview`.
+
+   You only need to set this if a single workflow file calls the `draft` or `submit` workflow more than once — for example, to submit two different kinds of content from separate directories. Each of those jobs comments on the same pull request, so unless they are given distinct titles they will find and overwrite each other's comment:
+
+   ```yaml
+   jobs:
+     journal-draft:
+       uses: curvenote/actions/.github/workflows/draft.yml@v1
+       with:
+         kind: article
+         path: journal-submissions/*
+         comment-title: Curvenote Preview (journal)
+         # ...
+     group-draft:
+       uses: curvenote/actions/.github/workflows/draft.yml@v1
+       with:
+         kind: example
+         path: group-submissions/*
+         comment-title: Curvenote Preview (group)
+         # ...
+   ```
+
+   Comments are matched by searching for the title within the comment body, so no title may be a prefix of another. Give every job a distinct suffix, as above — do not leave one job on the default `Curvenote Preview` while another uses `Curvenote Preview (group)`, since the default would also match the second comment.
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@curvenote/actions",
   "private": true,
-  "version": "1.0.20",
+  "version": "1.0.21",
   "workspaces": [
     "strategy",
     "submit-summary"

--- a/strategy/action.yml
+++ b/strategy/action.yml
@@ -5,11 +5,19 @@ branding:
   icon: package
   color: blue
 inputs:
-  changed-files:
+  changed-files-json:
     description: |
-      A comma-separated list of changed files.
+      Path to a JSON file containing an array of the changed file paths.
 
-      We recommend using https://github.com/tj-actions/changed-files
+      This is read from a file, rather than passed directly, as the list of changed
+      files can exceed the maximum size of an action input.
+
+      We recommend using https://github.com/tj-actions/changed-files with
+      `json: true`, `write_output_files: true` and `safe_output: false`, which
+      writes `all_changed_files.json` to its `output_dir`. We do not need safe output
+      as the list is read from a file, never interpolated into a shell, and
+      sanitizing it mangles paths with non-ASCII or special characters.
+          
     required: true
   monorepo:
     description: |

--- a/strategy/src/index.ts
+++ b/strategy/src/index.ts
@@ -7,6 +7,7 @@ import {
   filterPathsAndIdentifyUnknownChanges,
   getIdsFromPaths,
   hasIntersection,
+  readChangedFiles,
   resolvePaths,
 } from './utils.js';
 
@@ -31,7 +32,7 @@ import {
   const submitLabel = booleanOrLabels(core.getInput('submit-label'));
   const idPatternRegex = core.getInput('id-pattern-regex');
 
-  const changedFiles = core.getInput('changed-files').split(',');
+  const changedFiles = readChangedFiles(core.getInput('changed-files-json'));
   const prLabels = await getPullRequestLabels(octokit);
   const rawEnforceSingleFolder = booleanOrLabels(core.getInput('enforce-single-folder'));
   const enforceSingleFolder =

--- a/strategy/src/utils.spec.ts
+++ b/strategy/src/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   filterPathsAndIdentifyUnknownChanges,
   getIdsFromPaths,
   ensureUniqueAndValidIds,
+  readChangedFiles,
 } from './utils.js';
 
 vi.mock('fs', () => memfs.fs);
@@ -45,6 +46,54 @@ describe('utility tests', () => {
     ]);
     expect(await resolvePaths('posters', '*')).toEqual(['posters/poster-1', 'posters/poster-2']);
     expect(await resolvePaths('posters', '*')).toEqual(['posters/poster-1', 'posters/poster-2']);
+  });
+
+  it('readChangedFiles', () => {
+    memfs.vol.fromJSON({
+      '/tmp/outputs/all_changed_files.json': '["posters/poster-1/temp.tex","README.md"]',
+    });
+    expect(readChangedFiles('/tmp/outputs/all_changed_files.json')).toEqual([
+      'posters/poster-1/temp.tex',
+      'README.md',
+    ]);
+  });
+
+  it('readChangedFiles - unescaped special characters', () => {
+    // `safe_output: false` keeps paths with special/non-ASCII characters intact
+    memfs.vol.fromJSON({
+      '/tmp/outputs/all_changed_files.json': '["posters/café/figure (1).png"]',
+    });
+    expect(readChangedFiles('/tmp/outputs/all_changed_files.json')).toEqual([
+      'posters/café/figure (1).png',
+    ]);
+  });
+
+  it('readChangedFiles - empty list', () => {
+    memfs.vol.fromJSON({ '/tmp/outputs/all_changed_files.json': '[]' });
+    expect(readChangedFiles('/tmp/outputs/all_changed_files.json')).toEqual([]);
+  });
+
+  it.each([
+    ['no path', '', {}],
+    ['missing file', '/tmp/outputs/all_changed_files.json', {}],
+    [
+      'invalid json',
+      '/tmp/outputs/all_changed_files.json',
+      { '/tmp/outputs/all_changed_files.json': 'posters/poster-1/temp.tex' },
+    ],
+    [
+      'not an array',
+      '/tmp/outputs/all_changed_files.json',
+      { '/tmp/outputs/all_changed_files.json': '{"file":"temp.tex"}' },
+    ],
+    [
+      'not an array of strings',
+      '/tmp/outputs/all_changed_files.json',
+      { '/tmp/outputs/all_changed_files.json': '[{"file":"temp.tex"}]' },
+    ],
+  ])('readChangedFiles - %s throws', (_, changedFilesJson, files) => {
+    memfs.vol.fromJSON(files);
+    expect(() => readChangedFiles(changedFilesJson)).toThrow();
   });
 
   it('filterPathsAndIdentifyUnknownChanges - select correct path', () => {
@@ -133,6 +182,43 @@ describe('utility tests', () => {
     ).toEqual({
       filteredPaths: ['.'],
       unknownChangedFiles: [],
+    });
+  });
+  it('filterPathsAndIdentifyUnknownChanges - path . matches changes at the repository root', () => {
+    expect(filterPathsAndIdentifyUnknownChanges(['.'], ['README.md'])).toEqual({
+      filteredPaths: ['.'],
+      unknownChangedFiles: [],
+    });
+  });
+  it('filterPathsAndIdentifyUnknownChanges - path . allows all changes when unchanged included', () => {
+    expect(
+      filterPathsAndIdentifyUnknownChanges(['.'], ['posters/temp.tex', '.git/temp.bin'], true),
+    ).toEqual({
+      filteredPaths: ['.'],
+      unknownChangedFiles: [],
+    });
+  });
+  it('filterPathsAndIdentifyUnknownChanges - path . alongside other allowed paths', () => {
+    expect(
+      filterPathsAndIdentifyUnknownChanges(
+        ['.', 'posters/poster-1'],
+        ['posters/poster-1/temp.tex', '.git/temp.bin'],
+      ),
+    ).toEqual({
+      filteredPaths: ['.', 'posters/poster-1'],
+      unknownChangedFiles: [],
+    });
+  });
+  it('filterPathsAndIdentifyUnknownChanges - includeUnchanged returns all allowed paths', () => {
+    expect(
+      filterPathsAndIdentifyUnknownChanges(
+        ['posters/poster-1', 'posters/poster-2'],
+        ['posters/poster-1/temp.tex', '.git/temp.bin'],
+        true,
+      ),
+    ).toEqual({
+      filteredPaths: ['posters/poster-1', 'posters/poster-2'],
+      unknownChangedFiles: ['.git/temp.bin'],
     });
   });
 

--- a/strategy/src/utils.ts
+++ b/strategy/src/utils.ts
@@ -70,10 +70,44 @@ export async function resolvePaths(baseDir: string, pattern: string): Promise<st
  *
  * pathStartsWith('papers/my-paper.md', 'pa') returns false
  *
+ * The '.' base path is the repository root, which contains every path.
  */
 function pathStartsWith(fullPath: string, basePath: string) {
+  if (basePath === '.') return true;
   const fullSliced = fullPath.split('/').slice(0, basePath.split('/').length).join('/');
   return fullSliced === basePath;
+}
+
+/**
+ * Read the list of changed files from a JSON file.
+ *
+ * The changed files are read from a file, rather than passed in directly, as the list
+ * can exceed the maximum size of an action input. See `tj-actions/changed-files` with
+ * `json: true` and `write_output_files: true`.
+ *
+ * @param changedFilesJson Path to a JSON file containing an array of file paths
+ */
+export function readChangedFiles(changedFilesJson: string): string[] {
+  if (!changedFilesJson) {
+    throw new Error('No changed-files-json path was provided to the strategy action');
+  }
+  if (!fs.existsSync(changedFilesJson)) {
+    throw new Error(
+      `There is no changed files JSON file at "${changedFilesJson}"\nEnsure the changed files step runs in the same job with \`json: true\` and \`write_output_files: true\``,
+    );
+  }
+  let changedFiles: unknown;
+  try {
+    changedFiles = JSON.parse(fs.readFileSync(changedFilesJson).toString());
+  } catch {
+    throw new Error(`Unable to parse the changed files JSON file at "${changedFilesJson}"`);
+  }
+  if (!Array.isArray(changedFiles) || changedFiles.some((file) => typeof file !== 'string')) {
+    throw new Error(
+      `Expected an array of file paths in the changed files JSON file at "${changedFilesJson}"`,
+    );
+  }
+  return changedFiles as string[];
 }
 
 /**
@@ -101,13 +135,11 @@ export function filterPathsAndIdentifyUnknownChanges(
     return { filteredPaths: allowedPaths, unknownChangedFiles };
   }
   // Extract base paths from changedFiles
-  const changedPaths = changedFiles
-    .map((file) => {
-      const parts = file.split('/');
-      parts.pop(); // Remove the file name, keep the directory path
-      return parts.join('/'); // Rejoin to form the base path
-    })
-    .filter((p) => !!p);
+  const changedPaths = changedFiles.map((file) => {
+    const parts = file.split('/');
+    parts.pop(); // Remove the file name, keep the directory path
+    return parts.join('/') || '.'; // Files at the root of the repository are in '.'
+  });
 
   // Deduplicate changedPaths
   const uniqueChangedPaths = Array.from(new Set(changedPaths));
@@ -116,10 +148,6 @@ export function filterPathsAndIdentifyUnknownChanges(
   const filteredPaths = allowedPaths.filter((allowed) => {
     return uniqueChangedPaths.some((changed) => pathStartsWith(changed, allowed));
   });
-  // If '.' path is allowed, all changes are valid
-  if (allowedPaths.includes('.')) {
-    return { filteredPaths: [...filteredPaths, '.'], unknownChangedFiles: [] };
-  }
   return { filteredPaths, unknownChangedFiles };
 }
 

--- a/submit-summary/src/index.ts
+++ b/submit-summary/src/index.ts
@@ -5,6 +5,9 @@ import * as path from 'path';
 
 type Report = { status: 'pass' | 'fail'; optional?: boolean }[];
 
+// Must match the artifact name uploaded by the `submit` action.
+const ARTIFACT_PREFIX = 'submit-';
+
 function formatDateUTC(date: string): string {
   // for example: Mar 12, 2024, 11:36 AM
   if (!date) return '';
@@ -53,8 +56,14 @@ function reportSummaryMessage(report: Report | undefined, buildUrl: string) {
     include: { id: string; 'working-directory': string }[];
   };
 
+  // Only keep the artifacts that belong to this job's matrix.
+  const infoByArtifact = new Map(
+    matrix.include.map((info) => [`${ARTIFACT_PREFIX}${info.id}`, info]),
+  );
+  const artifacts = list.artifacts.filter(({ name }) => infoByArtifact.has(name));
+
   await Promise.all(
-    list.artifacts.map((a) =>
+    artifacts.map((a) =>
       artifact.downloadArtifact(a.id, {
         path: `logs/${a.name}`,
       }),
@@ -70,8 +79,9 @@ function reportSummaryMessage(report: Report | undefined, buildUrl: string) {
     .map((dir) => {
       const name = path.join('logs', dir, 'curvenote.submit.json');
       if (!fs.existsSync(name)) return null;
+      const info = infoByArtifact.get(dir);
+      if (!info) return null;
       const data = JSON.parse(fs.readFileSync(name).toString());
-      const info = matrix.include.find(({ id }) => id === dir.replace('submit-', ''));
       return { dir, data, info };
     })
     .filter(
@@ -83,6 +93,11 @@ function reportSummaryMessage(report: Report | undefined, buildUrl: string) {
         info: { id: string; 'working-directory': string };
       } => !!log,
     );
+  if (submitLogs.length === 0) {
+    // upsert-comment is dependent on the text of this comment; if you change it here, also change it there.
+    core.setOutput('comment', '📭 No submissions available to inspect.');
+    return;
+  }
 
   const table = `
 | Directory | Preview | Checks | Updated (UTC) |

--- a/upsert-comment/action.yml
+++ b/upsert-comment/action.yml
@@ -6,7 +6,12 @@ branding:
   color: blue
 inputs:
   title:
-    description: The title of the comment, put in bold at the top and ensures that the correct comment is updated
+    description: |
+      The title of the comment, put in bold at the top and ensures that the correct comment is updated.
+
+      If a single workflow calls this more than once (e.g. one job per path), each call must use a
+      distinct title, otherwise the jobs will overwrite each other's comment. No title may be a
+      prefix of another, as comments are matched by looking for the title within the comment body.
     default: Curvenote Preview
   comment:
     description: The body of the comment, in markdown
@@ -22,23 +27,6 @@ runs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
         body-includes: ${{ inputs.title }}
-    - name: Find "no submissions" PR Comment
-      if: ${{ github.event.pull_request.number }}
-      uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
-      id: fc-no-subs
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
-        body-includes: No submissions available to inspect.
-    - name: Find "stale" PR Comment
-      if: ${{ github.event.pull_request.number }}
-      uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
-      id: fc-stale
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
-        # later steps dependent on the text of this comment; if you change it here, also change it there.
-        body-includes: These previews are stale and may not reflect the current state of this PR.
     # If no comment exists at all, make a new comment.
     - name: Create new PR comment
       if: ${{ github.event.pull_request.number && steps.fc.outputs.comment-id == '' }}
@@ -66,7 +54,7 @@ runs:
     # - the new comment is "no submission available"
     # Then: append the "stale" message to the existing comment.
     - name: Append "stale" message to existing "successful" comment
-      if: ${{ github.event.pull_request.number && steps.fc.outputs.comment-id != '' && steps.fc-no-subs.outputs.comment-id == '' && steps.fc-stale.outputs.comment-id == '' && contains(inputs.comment, 'No submissions available to inspect.') }}
+      if: ${{ github.event.pull_request.number && steps.fc.outputs.comment-id != '' && !contains(steps.fc.outputs.comment-body, 'No submissions available to inspect.') && !contains(steps.fc.outputs.comment-body, 'These previews are stale and may not reflect the current state of this PR.') && contains(inputs.comment, 'No submissions available to inspect.') }}
       uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
Addresses #55 - I followed the second suggested fix of writing changed files to JSON, rather than passing as an action arg.